### PR TITLE
replace __proto__ with Object.getPrototypeOf

### DIFF
--- a/o.extend.js
+++ b/o.extend.js
@@ -18,7 +18,7 @@ if (!Object.hasOwnProperty('extend')) {
 
         var thisProps = Object.getOwnPropertyDescriptor(to, prop)
         if (!thisProps) {
-          thisProps = Object.getOwnPropertyDescriptor(to.__proto__, prop)
+          thisProps = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(to), prop)
         }
         if (thisProps) {
           if (destination.value && typeof thisProps.set === 'function') {


### PR DESCRIPTION
Fixes https://github.com/capaj/o.extend/issues/3

IE9 and IE10 do not have **proto** but do have Object.getPrototypeOf
